### PR TITLE
Refactor: Remove minLength from todo title schema

### DIFF
--- a/server/trpc/routers/todos/add.schema.ts
+++ b/server/trpc/routers/todos/add.schema.ts
@@ -1,7 +1,7 @@
 import * as v from 'valibot'
 
 export const VAddInputSchema = v.object({
-  title: v.pipe(v.string(), v.maxLength(100))
+  title: v.pipe(v.string(), v.minLength(1), v.maxLength(100))
 })
 
 export type TAddInputSchema = v.InferOutput<typeof VAddInputSchema>

--- a/server/trpc/routers/todos/add.schema.ts
+++ b/server/trpc/routers/todos/add.schema.ts
@@ -1,8 +1,7 @@
 import * as v from 'valibot'
 
 export const VAddInputSchema = v.object({
-  // ! If you see this comment in PR, Something is wrong
-  title: v.pipe(v.string(), v.minLength(4), v.maxLength(100))
+  title: v.pipe(v.string(), v.maxLength(100))
 })
 
 export type TAddInputSchema = v.InferOutput<typeof VAddInputSchema>


### PR DESCRIPTION
Removes the `minLength` validation from the todo title schema, allowing for shorter titles.