### PR TITLE
Impliment Email List

### DIFF
--- a/app/components/app/Sidebar.vue
+++ b/app/components/app/Sidebar.vue
@@ -15,22 +15,22 @@ const commonSidebarGroup = [
   {
     name: 'Starred',
     icon: 'material-symbols:star-rounded',
-    to: '/'
+    to: '/mails'
   },
   {
     name: 'Sent',
     icon: 'material-symbols:send-rounded',
-    to: '/'
+    to: '/mails'
   },
   {
     name: 'Drafts',
     icon: 'material-symbols:drafts-rounded',
-    to: '/'
+    to: '/mails'
   },
   {
     name: 'Promotions',
     icon: 'material-symbols:sell',
-    to: '/'
+    to: '/mails'
   }
 ]
 </script>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,8 +2,10 @@
   <UiSidebarProvider class="w-full max-w-screen flex relative">
     <AppSidebar />
     <main class="flex-col w-full min-w-0">
-      <div class="z-10 p-3">
-        <UiSidebarTrigger />
+      <div class="z-10 p-1 sticky inset-0 flex">
+        <div class="p-2 bg-background/30 backdrop-blur rounded-lg">
+          <UiSidebarTrigger />
+        </div>
       </div>
       <slot />
     </main>

--- a/app/pages/mails.vue
+++ b/app/pages/mails.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+// サンプルメールデータ
+const mails = ref([
+  {
+    id: 1,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 2,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 3,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 4,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 5,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 6,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 7,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 8,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 9,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 10,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 11,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 12,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  },
+  {
+    id: 13,
+    sender: 'ツジ 佐介',
+    subject: '今夜の社交ダンスについて',
+    isStarred: false,
+    avatar: null
+  }
+])
+
+const toggleStar = (mailId: number) => {
+  const mail = mails.value.find(m => m.id === mailId)
+  if (mail) {
+    mail.isStarred = !mail.isStarred
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full bg-background">
+    <!-- メール一覧 -->
+    <div class="flex-1 overflow-auto">
+      <div>
+        <div
+          v-for="mail in mails"
+          :key="mail.id"
+          class="flex items-center gap-4 p-4 hover:bg-muted/50 cursor-pointer transition-colors"
+        >
+          <!-- 星アイコン -->
+          <UiButton
+            variant="ghost"
+            size="sm"
+            class="h-8 w-8 p-0 hover:bg-transparent"
+            @click.stop="toggleStar(mail.id)"
+          >
+            <Icon
+              :name="mail.isStarred ? 'material-symbols:star-rounded' : 'material-symbols:star-outline-rounded'"
+              :class="mail.isStarred ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground'"
+              size="1.5em"
+            />
+          </UiButton>
+
+          <!-- アバター -->
+          <UiAvatar
+            :src="mail.avatar"
+            :alt="mail.sender"
+            size="sm"
+            class="h-10 w-10 bg-muted"
+          />
+
+          <!-- メール情報 -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-foreground truncate">
+                {{ mail.sender }}
+              </span>
+              <span class="text-muted-foreground truncate">
+                {{ mail.subject }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Refactor the sidebar trigger's container to use `sticky` positioning and add `backdrop-blur` for better visual integration. This ensures the trigger remains visible and accessible while scrolling.