### PR TITLE
feat: Add BetterAuth secret and update preview command

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,7 +35,8 @@ export default defineNuxtConfig({
     googleClientId: '',
     googleClientSecret: '',
     googleRedirectUrl: '',
-    databaseUrl: ''
+    databaseUrl: '',
+    betterAuthSecret: ''
   },
   build: {
     transpile: ['trpc-nuxt']

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "nuxi dev",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 nuxi build",
-    "preview": "npx nuxthub preview",
+    "preview": "pnpx nuxthub preview",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "lint": "eslint .",

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -16,6 +16,7 @@ export const serverAuth = () => {
       }
       return _databaseAdapter
     },
+    secret: config.betterAuthSecret!,
     socialProviders: {
       google: {
         prompt: 'consent',


### PR DESCRIPTION
Adds `betterAuthSecret` to `nuxt.config.ts` for use with `serverAuth`. Updates the `preview` script in `package.json` to use `pnpx` instead of `npx`.