### PR TITLE
fix: Cannot perform I/O on behalf of a different request.

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -2,20 +2,12 @@ import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { useDB } from './db'
 
-let _databaseAdapter: ReturnType<typeof drizzleAdapter> | null = null
-
 export const serverAuth = () => {
   const config = useRuntimeConfig(useEvent())
   return betterAuth({
-
-    get database() {
-      if (!_databaseAdapter) {
-        _databaseAdapter = drizzleAdapter(useDB(), {
-          provider: 'pg'
-        })
-      }
-      return _databaseAdapter
-    },
+    database: drizzleAdapter(useDB(), {
+      provider: 'pg'
+    }),
     secret: config.betterAuthSecret!,
     socialProviders: {
       google: {


### PR DESCRIPTION
There is an error when the user trying to log in, or call api that needs access token, so I fix that

## Error

```
Error: Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: Writable)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal authentication handling to improve reliability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->