### PR TITLE
Fix: Include cause in TRPCError for access token failures

### DIFF
--- a/server/trpc/routers/mails/archive.handler.ts
+++ b/server/trpc/routers/mails/archive.handler.ts
@@ -18,7 +18,8 @@ export async function archiveMailHandler({ input }: ArchiveMailOptions) {
   if (accessTokenError !== null) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to get Google access token.'
+      message: 'Failed to get Google access token.',
+      cause: accessTokenError
     })
   }
 

--- a/server/trpc/routers/mails/get.handler.ts
+++ b/server/trpc/routers/mails/get.handler.ts
@@ -18,7 +18,8 @@ export async function getHandler({ input }: getMailOptions) {
   if (accessTokenError !== null) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to get Google access token.'
+      message: 'Failed to get Google access token.',
+      cause: accessTokenError
     })
   }
 

--- a/server/trpc/routers/mails/list.handler.ts
+++ b/server/trpc/routers/mails/list.handler.ts
@@ -18,7 +18,8 @@ export async function listHandler({ input }: listMailsOptions) {
   if (accessTokenError !== null) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to get Google access token.'
+      message: 'Failed to get Google access token.',
+      cause: accessTokenError
     })
   }
 

--- a/server/trpc/routers/mails/toggleStar.handler.ts
+++ b/server/trpc/routers/mails/toggleStar.handler.ts
@@ -18,7 +18,8 @@ export async function toggleStarHandler({ input }: ToggleStarOptions) {
   if (accessTokenError !== null) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to get Google access token.'
+      message: 'Failed to get Google access token.',
+      cause: accessTokenError
     })
   }
 

--- a/server/trpc/routers/mails/trash.handler.ts
+++ b/server/trpc/routers/mails/trash.handler.ts
@@ -18,7 +18,8 @@ export async function trashMailHandler({ input }: TrashMailOptions) {
   if (accessTokenError !== null) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to get Google access token.'
+      message: 'Failed to get Google access token.',
+      cause: accessTokenError
     })
   }
 


### PR DESCRIPTION
Adds the `cause` property to `TRPCError` instances thrown when failing to obtain a Google access token. This provides more detailed error information for debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for Google access token failures to include additional context, making troubleshooting easier for users when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->