### PR TITLE
Feat: Update Google OAuth scope for full Gmail access

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -11,12 +11,11 @@ export const serverAuth = () => {
     secret: config.betterAuthSecret!,
     socialProviders: {
       google: {
-        prompt: 'consent',
         accessType: 'offline',
         clientId: config.googleClientId!,
         clientSecret: config.googleClientSecret!,
         callbackUrl: config.googleRedirectUrl!,
-        scope: ['https://www.googleapis.com/auth/gmail.readonly']
+        scope: ['https://mail.google.com/']
       }
     }
   })


### PR DESCRIPTION
Removes the `prompt: 'consent'` option because it is kind of annoying.
Changes the Google OAuth scope from `gmail.readonly` to `https://mail.google.com/` to allow full access to Gmail or the user cannot modify, delete or archive mails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Google authentication settings to use a different OAuth scope and removed the consent prompt for sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->