### PR TITLE
feat(mails): Route sidebar links to specific mail types

### DIFF
--- a/app/components/app/Sidebar.vue
+++ b/app/components/app/Sidebar.vue
@@ -16,22 +16,22 @@ const commonSidebarGroup = [
   {
     name: 'Starred',
     icon: 'material-symbols:star-rounded',
-    to: '/mails'
+    to: '/mails?is=STARRED'
   },
   {
     name: 'Sent',
     icon: 'material-symbols:send-rounded',
-    to: '/mails'
+    to: '/mails?is=SENT'
   },
   {
     name: 'Drafts',
     icon: 'material-symbols:drafts-rounded',
-    to: '/mails'
+    to: '/mails?is=DRAFT'
   },
   {
     name: 'Promotions',
     icon: 'material-symbols:sell',
-    to: '/mails'
+    to: '/mails?is=PROMOTION'
   }
 ]
 </script>

--- a/app/pages/mails.vue
+++ b/app/pages/mails.vue
@@ -1,22 +1,29 @@
 <script setup lang="ts">
-import { useDebounceFn, useEventListener } from '@vueuse/core'
+import { useDebounceFn, useEventListener, useUrlSearchParams } from '@vueuse/core'
 
+definePageMeta({
+  key: ({ query }) => `mails/${query.is || ''}`
+})
 // サンプルメールデータ
-const { $trpc, $router } = useNuxtApp()
-const route = useRoute()
+const { $trpc } = useNuxtApp()
 const mailListEl = useTemplateRef('mail-list')
-const selectedMailId = ref(route.query.id as string | undefined)
+const params = useUrlSearchParams<{
+  mailId: string | undefined
+  is: string | undefined
+}>('history')
 const selectedMail = ref<HTMLElement | null>(null)
 const { data: mail } = useQuery({
-  key: () => ['mail', selectedMailId.value || 'null'],
+  key: () => ['mail', params.mailId || 'null'],
   query: async () => {
-    if (!selectedMailId.value) return null
-    return await $trpc.mails.get.query({ id: selectedMailId.value as string })
+    if (!params.mailId) return null
+    return await $trpc.mails.get.query({ id: params.mailId })
   }
 })
 const { data: mails } = useQuery({
-  key: ['mails'],
-  query: () => $trpc.mails.list.query({})
+  key: () => ['mails', `is:${params.is || ''}`],
+  query: () => $trpc.mails.list.query({
+    q: `is:${params.is || ''}`
+  })
 })
 
 const firstMailEl = computed(() => {
@@ -66,7 +73,7 @@ const { mutate: trash } = useMailMutation(
 )
 
 useEventListener('keydown', (e) => {
-  if (selectedMailId.value) return
+  if (params.mailId) return
   switch (e.key) {
     case 'k':
     case 'ArrowUp': {
@@ -94,11 +101,7 @@ useEventListener('keydown', (e) => {
 })
 
 onBeforeRouteUpdate((to) => {
-  selectedMailId.value = to.query.id as string | undefined
-})
-
-watchEffect(() => {
-  $router.push(selectedMailId.value ? `/mails?id=${selectedMailId.value}` : '/mails')
+  params.mailId = to.query.id as string | undefined
 })
 
 watchEffect(() => {
@@ -111,8 +114,8 @@ watchEffect(() => {
   <div class="flex flex-col h-full bg-background">
     <!-- メール一覧 -->
     <UiSheet
-      :open="!!selectedMailId"
-      @update:open="selectedMailId = undefined"
+      :open="!!params.mailId"
+      @update:open="params.mailId= undefined"
     >
       <UiSheetContent class="sm:max-w-2xl overflow-y-auto outline-none">
         <div class="h-full">
@@ -159,12 +162,12 @@ watchEffect(() => {
           :key="mail.id"
           :to="`/mails?id=${mail.id}`"
           role="listitem"
-          :aria-selected="selectedMailId === mail.id"
+          :aria-selected="params.mailId=== mail.id"
           :aria-label="`Email from ${mail.from}: ${mail.subject}`"
           tabindex="-1"
           class="w-full flex outline-none items-center gap-4 p-4 hover:bg-muted/50 focus:bg-muted/50 cursor-pointer"
-          @click="selectedMailId = mail.id"
-          @keydown.enter.space.prevent="selectedMailId = mail.id"
+          @click="params.mailId= mail.id"
+          @keydown.enter.space.prevent="params.mailId= mail.id"
           @keydown.s.prevent="toggleStar(mail)"
           @keydown.a.prevent="archive(mail)"
           @keydown.d.prevent="trash(mail)"


### PR DESCRIPTION
This commit updates the sidebar navigation to include query parameters that specify the type of mail to display (e.g., STARRED, SENT, DRAFT, PROMOTION).

The `mails.vue` page has been refactored to utilize `useUrlSearchParams` to manage these query parameters, including the `mailId` for displaying individual emails. This change also enhances the routing key for `mails.vue` to correctly handle different mail types and individual email views.

The keyboard navigation and mail selection logic in `mails.vue` have been updated to use the new `params.mailId` and `params.is` from `useUrlSearchParams`. The `UiSheet` component's open state is now also controlled by `params.mailId`.

This change improves the organization and navigation within the mail application by allowing direct access to different mail categories via the sidebar.