### PR TITLE
Enhance the sidebar transition

### DIFF
--- a/app/components/app/Sidebar.vue
+++ b/app/components/app/Sidebar.vue
@@ -39,13 +39,14 @@ const commonSidebarGroup = [
 
 <template>
   <UiSidebar>
-    <UiSidebarHeader class="py-4 flex justify-between">
+    <UiSidebarHeader class="py-4 flex flex-row justify-between">
       <UiButton
         size="icon"
         variant="ghost"
         icon="material-symbols:edit-rounded"
         @click="createDraft()"
       />
+      <AppSidebarTrigger show-on="open" />
     </UiSidebarHeader>
     <UiSidebarContent>
       <UiSidebarGroup>

--- a/app/components/app/SidebarTrigger.vue
+++ b/app/components/app/SidebarTrigger.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { useSidebar } from '../ui/sidebar'
+
+defineProps<{
+  showOn: 'open' | 'closed'
+}>()
+
+const { open } = useSidebar()
+</script>
+
+<template>
+  <Motion
+    is="div"
+    v-if="showOn === 'open' ? open : !open"
+    :transition="{
+      ease: [0.2, 0.0, 0, 1.0],
+      duration: 0.4
+    }"
+    class="inline-grid place-items-center size-9 backdrop-blur rounded-lg"
+    layout-id="sidebar-toggle"
+  >
+    <UiSidebarTrigger />
+  </Motion>
+</template>

--- a/app/components/ui/button/index.ts
+++ b/app/components/ui/button/index.ts
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 export { default as Button } from './Button.vue'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
   {
     variants: {
       variant: {
@@ -20,9 +20,9 @@ export const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline'
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        default: 'h-9 px-5 py-2 has-[>svg]:px-5',
+        sm: 'h-8 rounded-full gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-full px-6 has-[>svg]:px-4',
         icon: 'size-9'
       }
     },

--- a/app/components/ui/sidebar/Sidebar.vue
+++ b/app/components/ui/sidebar/Sidebar.vue
@@ -68,7 +68,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     <!-- This is what handles the sidebar gap on desktop  -->
     <div
       :class="cn(
-        'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-standard',
+        'relative w-(--sidebar-width) bg-transparent transition-[width] duration-400 ease-standard',
         'group-data-[collapsible=offcanvas]:w-0',
         'group-data-[side=right]:rotate-180',
         variant === 'floating' || variant === 'inset'
@@ -78,7 +78,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     />
     <div
       :class="cn(
-        'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-standard md:flex',
+        'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-400 ease-standard md:flex',
         side === 'left'
           ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
           : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',

--- a/app/components/ui/sidebar/SidebarGroupLabel.vue
+++ b/app/components/ui/sidebar/SidebarGroupLabel.vue
@@ -16,7 +16,7 @@ const props = defineProps<PrimitiveProps & {
     :as="as"
     :as-child="asChild"
     :class="cn(
-      'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-standard focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+      'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-400 ease-standard focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
       'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
       props.class)"
   >

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -3,8 +3,8 @@
     <AppSidebar />
     <main class="w-full min-w-0">
       <div class="z-10 p-1 sticky inset-0 flex">
-        <div class="p-2 bg-background/30 backdrop-blur rounded-lg">
-          <UiSidebarTrigger />
+        <div class="absolute inset-5">
+          <AppSidebarTrigger show-on="closed" />
         </div>
       </div>
       <slot />


### PR DESCRIPTION
Adds a new `SidebarTrigger.vue` component to conditionally render the sidebar toggle button based on the sidebar state (`open` or `closed`).

This component is integrated into `Sidebar.vue` to show the trigger when the sidebar is open, and into `default.vue` layout to show the trigger when the sidebar is closed.

Also includes related UI updates:
- Adjusts button styling (rounded corners for sizes `default` and `lg`).
- Increases transition durations for sidebar animations from 200ms to 400ms for smoother visual feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a contextual sidebar trigger that appears when the sidebar is closed for easier access.

- UI/UX
  - Updated header layout to improve alignment and spacing.
  - Increased sidebar and group label animation durations for smoother transitions.
  - Adjusted trigger placement to an overlay position for better visibility.

- Style
  - Updated button shapes to fully rounded (pill) with refined default, small, and large paddings for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->