### PR TITLE
Fix mail rendering logic

### DIFF
--- a/app/components/app/MailRenderer.vue
+++ b/app/components/app/MailRenderer.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+const props = defineProps<{
+  mail: FullMail
+}>()
+
+const mailContent = computed(() => {
+  if (!props.mail.isHTML)
+    return props.mail?.content.replaceAll('\n', '<br>') ?? ''
+  const document = new DOMParser().parseFromString(props.mail.content, 'text/html')
+  const style = Array.from(document.querySelectorAll('style')).map(s => `<style>${s.innerText.replaceAll(/body|html/g, ':host')}</style>`).join('')
+  document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+    // if the element has a background color, set the text color to black
+    // because most of the time, the background color is white-ish
+    if (el.style.background) {
+      el.style.color ||= '#000'
+    }
+  })
+  document.querySelectorAll('script').forEach(s => s.remove())
+  document.querySelectorAll('a').forEach(a => a.target = '_blank')
+  return `${style}${document.body.innerHTML}`
+})
+</script>
+
+<template>
+  <UiShadowRoot class="h-max px-4">
+    <div
+      :style="{
+        display: 'contents'
+      }"
+      v-html="mailContent"
+    />
+  </UiShadowRoot>
+</template>

--- a/app/pages/mails.vue
+++ b/app/pages/mails.vue
@@ -30,16 +30,6 @@ const firstMailEl = computed(() => {
   const first = mailListEl.value?.children[0]
   return first instanceof HTMLElement ? first : null
 })
-const mailContent = computed(() => {
-  if (!mail.value) return null
-  if (!mail.value?.isHTML)
-    return mail.value?.content ?? ''
-  const document = new DOMParser().parseFromString(mail.value.content, 'text/html')
-  const style = Array.from(document.querySelectorAll('style')).map(s => s.innerText).join().replaceAll(/body|html/g, ':host')
-  document.querySelectorAll('script').forEach(s => s.remove())
-  document.querySelectorAll('a').forEach(a => a.target = '_blank')
-  return `${style && `<style>${style}</style>`}${document.body.innerHTML}`
-})
 
 const debounceToggleStar = useDebounceFn(async (mail: Mail) => {
   return $trpc.mails.toggleStar.mutate({ id: mail.id, value: !isStarred(mail) })
@@ -144,15 +134,10 @@ watchEffect(() => {
               class="h-7"
             />
           </UiSheetHeader>
-          <UiShadowRoot
-            v-if="mailContent"
-            class="h-max px-4"
-          >
-            <div
-              style="display: contents;"
-              v-html="mailContent"
-            />
-          </UiShadowRoot>
+          <AppMailRenderer
+            v-if="mail"
+            :mail
+          />
           <UiSkeleton v-else />
         </div>
       </UiSheetContent>


### PR DESCRIPTION
Moves the logic for rendering raw or HTML emails from `app/pages/mails.vue` into a new reusable component, `app/components/app/MailRenderer.vue`.

This cleans up the main mail view page and centralizes HTML sanitization and content transformation (like replacing `body`/`html` selectors in styles and ensuring links open in new tabs).