### PR TITLE
Correctly determine message content type

### DIFF
--- a/server/services/gmail/gmail.service.ts
+++ b/server/services/gmail/gmail.service.ts
@@ -337,7 +337,7 @@ export class GmailService implements IGmailService {
           message.payload.body.data.replace(/-/g, '+').replace(/_/g, '/'),
           'base64'
         ).toString(),
-        isHTML: false
+        isHTML: message.payload.mimeType === 'text/html'
       }
     }
     return { content: '', isHTML: false }

--- a/server/types/gmail.d.ts
+++ b/server/types/gmail.d.ts
@@ -14,6 +14,8 @@ interface GmailMessagePayload {
   headers?: GmailMessageHeader[]
   body?: GmailMessageBody
   parts?: GmailMessagePart[]
+  mimeType: string
+  partId: string
 }
 
 interface GmailMessagePart {

--- a/server/types/gmail.d.ts
+++ b/server/types/gmail.d.ts
@@ -14,8 +14,8 @@ interface GmailMessagePayload {
   headers?: GmailMessageHeader[]
   body?: GmailMessageBody
   parts?: GmailMessagePart[]
-  mimeType: string
-  partId: string
+  mimeType?: string
+  partId?: string
 }
 
 interface GmailMessagePart {


### PR DESCRIPTION
Update Gmail service to check `mimeType` from the payload to accurately set `isHTML` flag for message content decoding.

Also updates TypeScript definitions to include `mimeType` and `partId` on `GmailMessagePayload`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly detect and render HTML vs. plain-text emails by using message MIME type, preventing HTML messages from appearing unformatted.
  * Improve handling of Gmail message payloads so content display and previews are more reliable across varied email formats.

* **Chores**
  * Extended payload typing to include optional MIME and part identifiers for more accurate content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->