### PR TITLE
fix(sidebar): correct promotion mail query parameter

### DIFF
--- a/app/components/app/Sidebar.vue
+++ b/app/components/app/Sidebar.vue
@@ -32,7 +32,7 @@ const commonSidebarGroup = [
   {
     name: 'Promotions',
     icon: 'material-symbols:sell',
-    to: '/mails?is=PROMOTION'
+    to: '/mails?is=PROMOTIONS'
   }
 ]
 </script>


### PR DESCRIPTION
The sidebar link for the 'Promotions' group was incorrectly using `is=PROMOTION` instead of the expected `is=PROMOTIONS` for filtering mails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Promotions menu to properly display promotional emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->